### PR TITLE
Este comportamiento está mal porque nos limitaba al momento de querer…

### DIFF
--- a/purchase_landing_costs/stock_move.py
+++ b/purchase_landing_costs/stock_move.py
@@ -40,9 +40,11 @@ class stock_move(osv.osv):
         if res.get('landing_costs_line_ids', False):
             res['landing_costs_line_ids'] = []
 
-        if res.get('price_unit_without_costs', False):
-            res['price_unit'] = res['price_unit_without_costs']
-            res['price_unit_without_costs'] = False
+        # Este comportamiento esta mal. Nos borra un campo que explicitamente queremos tener copiado.
+        #
+        #if res.get('price_unit_without_costs', False):
+        #    res['price_unit'] = res['price_unit_without_costs']
+        #    res['price_unit_without_costs'] = False
 
         return res
 


### PR DESCRIPTION
… hacer copy(), incluso poniendo lo que pusimos en odoo-ecuador-inventario, en la misma rama. Este comportamiento hay que eliminarlo para permitir así que el valor se escriba sin problemas y no quede en cero.
